### PR TITLE
Update Pager.php

### DIFF
--- a/Pager.php
+++ b/Pager.php
@@ -166,7 +166,7 @@ class Pager
      * @static
      * @access public
      */
-    function &factory($options = array())
+    static function &factory($options = array())
     {
         $mode = (isset($options['mode']) ? ucfirst($options['mode']) : 'Jumping');
         $classname = 'Pager_' . $mode;


### PR DESCRIPTION
Strict Standards: Non-static method Pager::factory() should not be called statically in /var/www/composer/index.php on line 27
